### PR TITLE
Fix footer to mimic expected design (#40)

### DIFF
--- a/css/footer.css
+++ b/css/footer.css
@@ -1,20 +1,22 @@
 footer {
     display: flex;
-    justify-content: space-evenly;
     padding: 20px;
     color: white;
     background: #212020;
     margin-top: auto;
+    width: 100%;
+    flex-direction: column;
+    align-items: center;
 }
 
 .additional {
     display: flex;
     flex-direction: column;
     flex-wrap: wrap;
+    text-align: center;
 }
 
 footer .f-ele1 {
-    margin: 1.4rem 0;
     border-radius: 8px;
     color: white;
     width: fit-content;
@@ -35,13 +37,14 @@ footer .f-ele1 {
 }
 
 .f-ele2 ul {
-
+    display: flex;
+    flex-direction: row;
     font-weight: bold;
     color: white;
 
 }
 
-.f-ele2 ul span {
+.f-ele2 span {
     color: white;
 
     font-size: 23px;
@@ -109,6 +112,18 @@ footer .f-ele1 {
     line-height: 25px;
 }
 
+/* copyright info styles */
+.f-ele4 {
+    margin-top: 20px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+#clg, #pp {
+    padding: 5px; 
+}
+
 
 /* End footer */
 /* Footer media queries */
@@ -138,7 +153,6 @@ footer .f-ele1 {
 @media (max-width:1095px) {
     footer {
         flex-direction: column;
-        gap: 32px;
     }
 
     .f-ele3 {
@@ -147,3 +161,28 @@ footer .f-ele1 {
         text-align: center;
     }
 }
+
+/* prevent text from overflowing footer */
+@media (max-width: 611px) {
+    #clg, #pp {
+        font-size: 16px; 
+    }
+}
+
+@media (max-width: 501px) {
+    #clg, #pp {
+        font-size: 10px; 
+    }
+}
+
+@media (max-width: 329px) {
+    .f-ele2 ul li {
+        font-size: 13px;
+    }
+
+    .f-ele2 ul {
+        flex-direction: column;
+    }
+}
+
+

--- a/index.html
+++ b/index.html
@@ -570,14 +570,11 @@
                 </div>
 
                 <br>
-                <div id="clg">Department of Artificial Intelligence, GHRCE</div>
-                <div id="pp">©2023 Jarvis</div>
 
             </div>
             <div class="f-ele2">
-
+               <span>Quick Links</span> 
                 <ul>
-                    <span>Quick Links</span>
                     <div></div>
                     <a href="#home">
                         <li>Home</li>
@@ -596,8 +593,7 @@
 
             <div class="f-ele3">
                 <ul>
-                    <span>Contact me</span><br>
-                    <br>
+                    <span>Contact me</span>
                 </ul>
 
                 <section id="lab_social_icon_footer" style="padding-top: 1px;">
@@ -618,6 +614,12 @@
                         </div>
                     </div>
                 </section>
+            </div>
+
+            <!-- move copyright info to bottom of footer -->
+            <div class="f-ele4">
+                <div id="clg">Department of Artificial Intelligence, GHRCE</div>
+                <div id="pp">©2023 Jarvis</div> 
             </div>
         </footer>
 


### PR DESCRIPTION
**HTML Changes**
- Created a new class for copyright info called "f-ele4". Moved it to the bottom of the footer to align with the expected design
- moved "Quick Links" span in "f-ele2" outside the list to apply separate styling 

**CSS Changes**
- expanded footer width to cover entire area 
- styled copyright info class to align with expected design
- styled footer with media queries to prevent text overflow on smaller screens

 **Screenshots**
 Desktop View:  
![image](https://github.com/jarvis-ghrce/Innovate-with-Open-Soucre/assets/110581427/ba5e5d12-bfc1-42be-b31d-611221f5c56d)

Mobile View: 
![image](https://github.com/jarvis-ghrce/Innovate-with-Open-Soucre/assets/110581427/990c9775-3d8f-4bff-816b-839f883d9210)
